### PR TITLE
include the namespace in the parameter declaration in getDescription …

### DIFF
--- a/software/src/master/src/kernel/Vxa_VSet.cpp
+++ b/software/src/master/src/kernel/Vxa_VSet.cpp
@@ -57,7 +57,7 @@ Vxa::VSet::~VSet () {
  *************************
  *************************/
 
-V::VString &Vxa::VSet::getDescription_(VString &rResult) const {
+V::VString &Vxa::VSet::getDescription_(V::VString &rResult) const {
     V::VRTTI iRTTI (typeid (*this));
     return rResult << iRTTI.name ();
 }

--- a/software/src/master/src/kernel/Vxa_VType.cpp
+++ b/software/src/master/src/kernel/Vxa_VType.cpp
@@ -58,7 +58,7 @@ Vxa::VType::~VType () {
  *************************
  *************************/
 
-V::VString &Vxa::VType::getDescription_(VString &rResult) const {
+V::VString &Vxa::VType::getDescription_(V::VString &rResult) const {
     V::VRTTI iRTTI (typeid (*this));
     return rResult << iRTTI.name ();
 }


### PR DESCRIPTION
…so that it will link under Solaris